### PR TITLE
Make image compatible with latest python cryptography changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# macOS created files to be ignored
+
+# General
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM alpine:3.11
+FROM python:3.8-alpine
 
-RUN apk --no-cache --update add build-base libffi-dev openssl-dev python3-dev python3 && \
-  pip3 install --no-cache-dir --upgrade "moto[server]~=1.3.0"
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev python3-dev libffi-dev openssl-dev cargo && \
+  pip3 install --no-cache-dir --upgrade "moto[server]~=1.3.0" && \
+  apk del --no-network .build-deps && \
+  rm -rf ~/.cargo/registry
 
 RUN addgroup moto \
-    && adduser -H -D -G moto moto
+  && adduser -H -D -G moto moto
 
 USER moto
 EXPOSE 4567

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A docker image using [Moto](https://github.com/spulec/moto) in [Stand-alone Server Mode](https://github.com/spulec/moto#stand-alone-server-mode), to provide a Python based implementation of [Amazon S3](https://aws.amazon.com/s3/). This can then be used in development and testing.
 
-Built on the Alpine 3.11 library image from Docker Hub.
+Built on the `python:3.8-alpine` library image from Docker Hub.
 
 Supports passing options (with the exception of `service`) to `moto_server` (also see the [Moto docs](http://docs.getmoto.org/en/latest/docs/server_mode.html):
 
@@ -51,7 +51,7 @@ $ docker run -d -p 4567:4567 countingup/moto_s3 --reload
 ## Usage in Docker Compose
 
 ```
-s3rver:
+moto_s3:
   image: countingup/moto_s3
   ports:
     # container port should be 4567


### PR DESCRIPTION
As per pyca/cryptography#4741 anything that depends on the Python cryptograhy library now needs Rust in order to compile on Alpine :-(

Dependencies to build taken from https://cryptography.io/en/latest/installation/#alpine

Also cleaned the Rust cargo registry to save ~260MB in the resulting image.

This makes the image usable again, but we should take another look at https://github.com/localstack/localstack for our AWS mocking needs.