### PR TITLE
Build and deploy image using Semaphore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,23 @@
+#
+# CI pipeline for building the countingup/moto_s3 Docker image and pushing to Docker Hub
+#
+name: Build and deploy image
+version: v1.0
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - name: Build and deploy image
+    task:
+      secrets:
+        - name: countingup-dockerhub
+      jobs:
+        - name: Build and deploy image
+          commands:
+            - checkout
+            - docker build -t countingup/moto_s3 .
+            - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
+            - docker push countingup/moto_s3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.8-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-moto_s3"
+
 RUN apk add --no-cache --upgrade --virtual .build-deps gcc musl-dev python3-dev libffi-dev openssl-dev cargo && \
   pip3 install --no-cache-dir --upgrade "moto[server]~=1.3.0" && \
   apk del --no-network .build-deps && \


### PR DESCRIPTION
Use Semaphore to build the image and push to Docker Hub. Replaces Docker Hub's Autobuild, which is becoming unavailable
on the free account tier.

Also add a label to the image that Snyk can use to monitor the repo.

[ch982]
